### PR TITLE
ダークモード自動切替を実装

### DIFF
--- a/lib/UI/config.dart
+++ b/lib/UI/config.dart
@@ -32,28 +32,34 @@ class _ConfigPageState extends State<ConfigPage> {
             ),
             body: Center(
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.start,
                 children: <Widget>[
                   SwitchWidget(
-                    title: 'ダークモード',
+                    title: 'ダークモード切替',
                     value: config.isDarkSwitch,
                     icon: Icon(Icons.lightbulb_outline),
-                    onChanged: (bool value) {
-                      Provider.of<MyTheme>(context, listen: false).toggle();
-                      Provider.of<ConfigInit>(context, listen: false)
-                          .toggle_dark_switch();
-                    },
-                    //テスト
+                    onChanged: config.isAutoDarkSwitch //ダークモード自動切替がonなら操作禁止
+                        ? null
+                        : (bool value) {
+                            Provider.of<MyTheme>(context, listen: false)
+                                .toggle();
+                            Provider.of<ConfigInit>(context, listen: false)
+                                .toggle_dark_switch();
+                          },
                   ),
-                  Text('スイッチテスト用'),
                   SwitchWidget(
-                      title: '☆テストだよ☆',
-                      value: config.isTestSwitch,
-                      icon: Icon(Icons.info),
-                      onChanged: (bool value) {
-                        Provider.of<ConfigInit>(context, listen: false)
-                            .toggle_test_switch();
-                      }),
+                    title: 'ダークモード自動切替',
+                    value: config.isAutoDarkSwitch,
+                    icon: Icon(Icons.lightbulb_outline),
+                    onChanged: config.isDarkSwitch //ダークモード切替がonなら操作禁止
+                        ? null
+                        : (bool value) {
+                            Provider.of<MyTheme>(context, listen: false)
+                                .auto_toggle();
+                            Provider.of<ConfigInit>(context, listen: false)
+                                .auto_toggle_dark_switch();
+                          },
+                  ),
                 ],
               ),
             ),

--- a/lib/UI/widgets/switch_widget.dart
+++ b/lib/UI/widgets/switch_widget.dart
@@ -10,8 +10,6 @@ class SwitchWidget extends StatelessWidget {
 
   final String title;
   final Icon icon;
-
-  // final String subtitle;
   final bool value;
   final void Function(bool)? onChanged;
 
@@ -19,7 +17,6 @@ class SwitchWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return SwitchListTile(
       title: Text(title),
-      // subtitle: Text('ダークモード切り替え'),
       value: value,
       onChanged: onChanged,
       secondary: icon,

--- a/lib/config/MyTheme.dart
+++ b/lib/config/MyTheme.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:intl/intl.dart';
 
 class MyTheme extends ChangeNotifier {
   ThemeData current = ThemeData.light();
-  bool _isDark = false;
+  bool _isDark = false; //ダークモードon,off
+  bool _isAutoDark = false; //ダークモード自動on,off
 
   MyTheme() {
     _init();
@@ -11,12 +13,20 @@ class MyTheme extends ChangeNotifier {
 
   ThemeData get mode => current;
   bool get isDark => _isDark;
+  bool get isAutoDark => _isAutoDark;
 
   void _init() async {
     final pref = await SharedPreferences.getInstance();
     _isDark = pref.getBool('isDark') ?? false;
-    current = _isDark ? ThemeData.dark() : ThemeData.light();
-    notifyListeners();
+    _isAutoDark = pref.getBool('isAutoDark') ?? false;
+    //アプリ起動時に、ダークモード自動切替がonなら時間を取得して、モード変更を行う。
+    if (_isAutoDark) {
+      await current_time();
+      //offならダークモード切替に従いモード変更
+    } else {
+      current = _isDark ? ThemeData.dark() : ThemeData.light();
+      notifyListeners();
+    }
   }
 
   toggle() async {
@@ -24,6 +34,33 @@ class MyTheme extends ChangeNotifier {
     final pref = await SharedPreferences.getInstance();
     pref.setBool('isDark', _isDark);
     current = _isDark ? ThemeData.dark() : ThemeData.light();
+    notifyListeners();
+  }
+
+  current_time() async {
+    var now = DateTime.now();
+    var timeFormat = DateFormat('HH'); //現在時刻[hour]を取得
+    var currentTime = timeFormat.format(now);
+    var current_time_int = int.parse(currentTime); //intに変換
+    //6-20時の間はライトモード
+    if (current_time_int >= 6 && current_time_int <= 20) {
+      current = ThemeData.light();
+    } else {
+      current = ThemeData.dark();
+    }
+    notifyListeners();
+  }
+
+  auto_toggle() async {
+    _isAutoDark = !_isAutoDark;
+    final pref = await SharedPreferences.getInstance();
+    pref.setBool('isAutoDark', _isAutoDark);
+    //ダークモード自動切替をonにしたら一度現在時刻を取得し判定しモード切替を行う
+    if (_isAutoDark == true) {
+      await current_time();
+    } else {
+      current = ThemeData.light();
+    }
     notifyListeners();
   }
 }

--- a/lib/config/config_init.dart
+++ b/lib/config/config_init.dart
@@ -1,27 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sola/config/MyTheme.dart';
 
 /*
 設定ページの設定をDBに保存する。
 */
 class ConfigInit extends ChangeNotifier {
-  bool _isDarkSwitch = false;
-  //test
-  bool _isTestSwitch = false;
+  bool _isDarkSwitch = false; //ダークモード切替のスイッチon,off
+  bool _isAutoDarkSwitch = false; //ダークモード自動切替のスイッチon,off
 
   ConfigInit() {
     _init();
   }
 
   bool get isDarkSwitch => _isDarkSwitch;
-  //test
-  bool get isTestSwitch => _isTestSwitch;
+  bool get isAutoDarkSwitch => _isAutoDarkSwitch;
 
   void _init() async {
     final pref = await SharedPreferences.getInstance();
     _isDarkSwitch = pref.getBool('isDarkSwitch') ?? false;
-    _isTestSwitch = pref.getBool('isTestSwitch') ?? false;
-
+    _isAutoDarkSwitch = pref.getBool('isAutoDarkSwitch') ?? false;
     notifyListeners();
   }
 
@@ -32,12 +30,10 @@ class ConfigInit extends ChangeNotifier {
     notifyListeners();
   }
 
-  //テスト
-
-  toggle_test_switch() async {
-    _isTestSwitch = !_isTestSwitch;
+  auto_toggle_dark_switch() async {
+    _isAutoDarkSwitch = !_isAutoDarkSwitch;
     final pref = await SharedPreferences.getInstance();
-    pref.setBool('isTestSwitch', _isTestSwitch);
+    pref.setBool('isAutoDarkSwitch', _isAutoDarkSwitch);
     notifyListeners();
   }
 }


### PR DESCRIPTION
設定機能にダークモード自動切替を実装。
6－20時にライトモード
それ以外はダークモード
二つがバッティングしないように、変数を分けて、ボタンの無効化も追加。